### PR TITLE
Fix top level constant lookup

### DIFF
--- a/rbtagger.el
+++ b/rbtagger.el
@@ -122,7 +122,7 @@ will return just Foo due to syntax table differences.  In
         (when (not (eq symbol-start-point symbol-end-point))
           (setq tag (substring-no-properties
                      (buffer-substring symbol-start-point symbol-end-point)))
-          (replace-regexp-in-string "^:\\([^:]+\\)" "\\1" tag))))))
+          (replace-regexp-in-string "^::?\\([^:]+\\)" "\\1" tag))))))
 
 (defun rbtagger-current-indent-level ()
   "Return indentation level according to Ruby mode."

--- a/test/rbtagger-test.el
+++ b/test/rbtagger-test.el
@@ -144,7 +144,7 @@
   (test-with-buffer-contents
    "module Bat\n  ::Top::Level.bar\nend"
    "Top"
-   (should (equal "::Top::Level" (rbtagger-symbol-at-point)))))
+   (should (equal "Top::Level" (rbtagger-symbol-at-point)))))
 
 (ert-deftest rbtagger-tag-lookup-accuracy ()
   (find-file "fixtures/integration/root.rb")


### PR DESCRIPTION
Lookup for `::Constant` should look for `Constant` and not `::Constant`. The specification was wrong.