### PR TITLE
Polish up latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ After that, you can install RbTagger with the following command:
 
 <kbd>M-x</kbd> `package-install` <kbd>[RET]</kbd> `rbtagger` <kbd>[RET]</kbd>
 
+I recommend installing the
+[`projectile`](https://github.com/bbatsov/projectile) package (also
+available on MELPA) and enabling `(projectile-mode)` globally to get
+goodies such as automatic visiting `TAGS` on `projectile-find-file`
+and similar commands, otherwise you'll have to visit the `TAGS` file
+manually.
+
 ## Generating tags
 
 To generate `TAGS`, make sure the current buffer belongs to a Ruby

--- a/rbtagger.el
+++ b/rbtagger.el
@@ -61,7 +61,8 @@ You can include the project name with the %s format string."
   :type 'string
   :group 'rbtagger)
 
-(defcustom rbtagger-generate-tags-bin (concat (file-name-directory load-file-name)
+(defcustom rbtagger-generate-tags-bin (concat (file-name-directory
+                                               (or load-file-name (buffer-file-name)))
                                               "bin/ruby_index_tags")
   "The full path to the script that generates the TAGS file.
 The script should take a \"directory\" argument or use the

--- a/rbtagger.el
+++ b/rbtagger.el
@@ -192,11 +192,13 @@ Takes PROJECT-NAME."
 Takes PROJECT-DIR and optionally GENERATE-TAGS-BIN.  If GENERATE_TAGS-BIN
 is not passed, it uses the `rbtagger-generate-tags' setting."
   (interactive (list (locate-dominating-file default-directory ".git")))
-  (let* ((project-dir (expand-file-name (string-remove-suffix "/" project-dir)))
+  (let* ((project-dir (or project-dir
+                          (error "Project git directory could not be found")))
+         (project-dir (expand-file-name (string-remove-suffix "/" project-dir)))
          (generate-tags-bin (or generate-tags-bin rbtagger-generate-tags-bin))
          (generate-tags-bin (expand-file-name generate-tags-bin)))
     (unless (file-directory-p project-dir)
-      (error "Project directory could not be found"))
+      (error "Project git directory could not be found"))
     (unless (file-exists-p generate-tags-bin)
       (error "Binary to generate Ruby tags could not be found"))
     (unless (file-executable-p generate-tags-bin)

--- a/test/rbtagger-test.el
+++ b/test/rbtagger-test.el
@@ -176,6 +176,11 @@
    (rbtagger-generate-tags "non_existing_directory"
                            "fixtures/bin/ruby_index_tags_success")))
 
+(ert-deftest rbtagger-generate-tags-nil-project-dir ()
+  (should-error-with-message
+   "could not be found"
+   (rbtagger-generate-tags nil "fixtures/bin/ruby_index_tags_success")))
+
 (ert-deftest rbtagger-generate-tags-invalid-binary-path ()
   (should-error-with-message
    "could not be found"


### PR DESCRIPTION
- Prevent error when re-evaluating rbtagger.el
- Prevent error when running `rbtagger-generate-tags` and there is no git project
- Improve installation instructions (recommend Projectile)