### PR TITLE
Implement universal argument on rbtagger-find-definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,10 @@ at point with <kbd>M-.</kbd>, which is a shortcut for <kbd>M-x</kbd>
 `rbtagger-find-definitions`. The above keybinding replaces Emacs'
 keybinding to `xref-find-definitions`.
 
-For popping back to where you were before, the command is still
+You can also force displaying a prompt of tags to choose from with the
+universal argument: `C-u M-.`.
+
+To pop back to where you were before, the command is still
 <kbd>M-.</kbd> or <kbd>M-x</kbd> `xref-pop-marker-stack`, which is a
 default `xref` command.
 

--- a/rbtagger.el
+++ b/rbtagger.el
@@ -101,11 +101,16 @@ your tags file was parsed with ripper-tags --emacs and --extra=q
 options."
   (interactive
    (let ((symbol (rbtagger-symbol-at-point)))
-     (when (string= symbol "")
-       (setq symbol (completing-read "Find definitions of: "
+     (when (or current-prefix-arg (string= symbol ""))
+       (setq symbol (completing-read (concat "Find definitions of"
+                                             (if (string= symbol "")
+                                                 ""
+                                               (concat " (" symbol ")"))
+                                             ": ")
                                      (xref-backend-identifier-completion-table 'etags)
                                      nil nil nil
-                                     'xref--read-identifier-history))
+                                     'xref--read-identifier-history
+                                     symbol))
        (if (string= symbol "") (error "Please, specify a symbol!")))
      (list symbol)))
   (let* ((top-level-constant-p (string-prefix-p "::" symbol))


### PR DESCRIPTION
Closes #21 

Integration tests for this feature would be pretty clunky, so I'm skipping them.