### PR TITLE
Improve indexing script error handling

### DIFF
--- a/bin/ruby_index_tags
+++ b/bin/ruby_index_tags
@@ -22,8 +22,10 @@ function index_main_project {
 }
 
 function index_dir {
-    ripper-tags --extra=q --recursive --emacs \
-                --exclude=.git "$@" > /dev/null
+    if ! ripper-tags --extra=q --recursive --emacs \
+         --exclude=.git "$@" > /dev/null; then
+        abort "Ripper tags failed! Is it really installed? Is the shim a valid reference to the ripper-tags script?"
+    fi
 }
 
 function index_project_gems {

--- a/rbtagger.el
+++ b/rbtagger.el
@@ -240,7 +240,8 @@ Takes PROJECT-NAME."
       (run-hook-with-args 'rbtagger-after-generate-tag-hook success project-name)
       (if success
           (message "Ruby tags successfully generated")
-        (message "ERROR: Ruby tags generation failed!")))))
+        (message (concat "ERROR: Ruby tags generation failed! Please check "
+                         (format rbtagger-stderr-buffer project-name)))))))
 
 ;;;###autoload
 (defun rbtagger-generate-tags (project-dir &optional generate-tags-bin)


### PR DESCRIPTION
I faced a situation where a shim for `ripper-tags` existed but the gem was not installed.