### PR TITLE
Fix top level constant lookup && include tip about completion prompt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
 env:
   - EMACS_CI=emacs-25-3
   - EMACS_CI=emacs-26-3
-  - EMACS_CI=emacs-snapshot
 install:
   # The default "emacs" executable on the $PATH will now be the version named by $EMACS_CI
   - bash <(curl https://raw.githubusercontent.com/purcell/nix-emacs-ci/master/travis-install)

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ Here is a list of commands:
 I strongly recommend reading up this guide for more details on how to
 best use this package.
 
+**TIP**: In the tag prompt, both `TAB` and `?` are set to trigger
+autocomplete or display the available tag completions. To insert a
+literal question mark in the completion prompt (which is a valid
+character for Ruby methods), type `C-q ?`.
+
 ## Generating tags
 
 To generate `TAGS`, make sure the current buffer belongs to a Ruby

--- a/rbtagger.el
+++ b/rbtagger.el
@@ -181,7 +181,9 @@ symbols but not in the command `ruby-mode'."
               (point)))
       (setq tag (substring-no-properties
                  (buffer-substring symbol-start-point symbol-end-point)))
-      (replace-regexp-in-string "^::?\\([^:]+\\)" "\\1" tag))))
+      (cond ((string-match "^::[A-Z]" tag) tag) ;; top-level constant
+            ((string-prefix-p ":" tag) (substring tag 1)) ;; symbol
+            (t tag)))))
 
 (defun rbtagger-current-indent-level ()
   "Return indentation level according to Ruby mode."

--- a/test/rbtagger-test.el
+++ b/test/rbtagger-test.el
@@ -139,7 +139,7 @@
 (rbtagger-buffer-deftest rbtagger-symbol-at-point-top-level-constant ()
   "module Bat\n  ::Top::Level.bar\nend"
   "Top"
-  (should (equal "Top::Level" (rbtagger-symbol-at-point))))
+  (should (equal "::Top::Level" (rbtagger-symbol-at-point))))
 
 ;; xref-find-definitions would present a list of two tags to choose
 ;; from: Base and ActiveRecord::Base, while rbtagger jumps straight to


### PR DESCRIPTION
I've accidentally introduced a regression at some point and top constant lookups stopped working. 