### PR TITLE
Fix bundle list paths when debug output is involved

### DIFF
--- a/bin/ruby_index_tags
+++ b/bin/ruby_index_tags
@@ -34,7 +34,7 @@ function index_project_gems {
 
     cd "$project_dir"
 
-    if ! gem_list=$(bundle list --paths); then
+    if ! gem_list=$(bundle list --paths | grep -e "^/"); then
         abort "Command to list gems failed. Bundler returned an error."
     fi
 


### PR DESCRIPTION
Fixes #45 

For some users, `bundle list --paths` will output debug lines that make the script fail. I'd expect only filesystem paths to come out of this command.

I assume this is either a bundler's bug or some debug flag turned on.

We can deal with this problem defensively by selecting the output lines that correspond to actual paths, or we can figure out in more detail how the problem happens and if there is any debug flag involved.