### PR TITLE
Allow generating tags on after save hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Ruby buffers:
 ```
 
 You can generate tags for the current Ruby project with <kbd>M-x</kbd>
-`rbtagger-generate-tags`. I strongly recommend setting up [git
-hooks](#git-hooks) for a better experience and to trigger this command
-manually less often.
+`rbtagger-generate-tags`. I strongly recommend setting up automation
+either through an [`after-save`](#after-save-hook) hook or [git hooks](#git-hooks) for a
+better experience.
 
 After enabling the minor mode, you can find definitions for the symbol
 at point with <kbd>M-.</kbd>, which is a shortcut for <kbd>M-x</kbd>
@@ -219,6 +219,22 @@ no prompts. Save them in `init.el`:
 ;; Reread TAGS without querying if it has changed
 (setq tags-revert-without-query 1)
 ```
+
+## After save hook
+
+You can automate tags generation with an after save hook. If you want
+to update your TAGS every time you save a Ruby file, you can setup a
+hook like this in your Emacs config:
+
+```elisp
+(add-hook 'after-save-hook
+          (lambda ()
+            (if (eq major-mode 'enh-ruby-mode)
+             (call-interactively 'rbtagger-generate-tags))))
+```
+
+If you use `ruby-mode` instead of `enh-ruby-mode`, just replace
+`enh-ruby-mode` in the above snippet.
 
 ## Git hooks
 

--- a/bin/ruby_index_tags
+++ b/bin/ruby_index_tags
@@ -1,28 +1,81 @@
 #!/usr/bin/env bash
 set -e
 
+function current_timestamp {
+    echo $(date +%s)
+}
+
 project_dir=${1:-.}
+lock_file="${project_dir}/.rbtagger-lock"
 gemfile="${project_dir}/Gemfile"
 temp_tags_file="${project_dir}/TAGS.$$" # Suffix with PID to make it unique
 final_tags_file="${project_dir}/TAGS"
-
-trap '/bin/rm -f $temp_tags_file' EXIT
+lock_timeout_seconds=300 # 5 minutes
 
 function warn {
-    local message=$1
+    local message=$@
 
     echo "$message" 1>&2
 }
 
 function abort {
-    local message=$1
+    local message=$@
 
     warn "$message"
     exit 1
 }
 
+function check_if_script_can_run {
+    if ! command -v gem > /dev/null; then
+        abort "Can't find gem command. Ruby doesn't seem to be installed."
+    fi
+
+    if ! command -v ripper-tags > /dev/null; then
+        echo "Installing ripper-tags gem..."
+        gem install ripper-tags
+    fi
+
+    if ! command -v bundler > /dev/null; then
+        # We don't automatically install bundler because the user might
+        # prefer a specific version.
+        abort "Can't find bundler. Make sure to gem install bundler."
+    fi
+
+    if [[ ! -f $gemfile ]]; then
+        abort "Could not generate tags. Are you in a Ruby project directory?"
+    fi
+}
+
+function cleanup {
+    rm -f "$temp_tags_file" "$lock_file"
+}
+
+function wait_on_lock {
+    local start_timestamp=$(current_timestamp)
+    local elapsed_seconds
+
+    while [[ -f "$lock_file" ]]; do
+        elapsed_seconds=$(($(current_timestamp) - $start_timestamp))
+
+        if [[ "$elapsed_seconds" -ge "$lock_timeout_seconds" ]]; then
+            abort "Timeout of ${lock_timeout_seconds} seconds exceeded!" \
+                  "If the script is not running, manually delete" \
+                  "the ${lock_file} stale lock file"
+        fi
+
+        sleep 1
+    done
+}
+
+function lock {
+    touch "$lock_file"
+}
+
+
 function index_main_project {
     local temp_tags_file=$1
+
+    echo "Indexing main project..."
 
     ripper_tags_wrapper --tag-file "$temp_tags_file" "$project_dir"
 }
@@ -126,26 +179,11 @@ function should_index_git_dir {
     fi
 }
 
-if ! command -v gem > /dev/null; then
-    abort "Can't find gem command. Ruby doesn't seem to be installed."
-fi
+check_if_script_can_run
+wait_on_lock
+lock
 
-if ! command -v ripper-tags > /dev/null; then
-    echo "Installing ripper-tags gem..."
-    gem install ripper-tags
-fi
-
-if ! command -v bundler > /dev/null; then
-    # We don't automatically install bundler because the user might
-    # prefer a specific version.
-    abort "Can't find bundler. Make sure to gem install bundler."
-fi
-
-if [[ ! -f $gemfile ]]; then
-    abort "Could not generate tags. Are you in a Ruby project directory?"
-fi
-
-echo "Indexing main project..."
+trap "cleanup" EXIT
 
 index_main_project "$temp_tags_file"
 index_stdlib "$temp_tags_file"


### PR DESCRIPTION
## Basic changelog

- Lock and queue up runs while generating tags. Without that, using an after save hook would not be so nice.
- Update `README` with a snippet suggestion to setup an after save hook.