### PR TITLE
Improve ripper tags detection and auto install

### DIFF
--- a/bin/ruby_index_tags
+++ b/bin/ruby_index_tags
@@ -30,7 +30,7 @@ function check_if_script_can_run {
         abort "Can't find gem command. Ruby doesn't seem to be installed."
     fi
 
-    if ! command -v ripper-tags > /dev/null; then
+    if ! ripper-tags --help > /dev/null 2>&1; then
         echo "Installing ripper-tags gem..."
         gem install ripper-tags
     fi
@@ -83,8 +83,7 @@ function index_main_project {
 function ripper_tags_wrapper {
     if ! ripper-tags --extra=q --recursive --emacs \
          --exclude=.git "$@" > /dev/null; then
-        abort "Ripper tags failed! Is it really installed? " \
-              "Is the shim a valid reference to the ripper-tags script?"
+        abort "Ripper tags failed"
     fi
 }
 


### PR DESCRIPTION
Sometimes an executable shim for ripper-tags will exist but it won't
point at the actual command. The new code introduced here tries to
execute ripper-tags to see if it works, and if not, install it.
