### PR TITLE
Add --force option to ripper-tags

### DIFF
--- a/bin/ruby_index_tags
+++ b/bin/ruby_index_tags
@@ -81,7 +81,7 @@ function index_main_project {
 }
 
 function ripper_tags_wrapper {
-    if ! ripper-tags --extra=q --recursive --emacs \
+    if ! ripper-tags --extra=q --force --recursive --emacs \
          --exclude=.git "$@" > /dev/null; then
         abort "Ripper tags failed"
     fi


### PR DESCRIPTION
Sometimes tags parsing would fail because of some problem or incompatibility with the parsed Ruby code, and that would halt the indexing script.

`rbtagger` is supposed to be low friction, so we should index as much code as possible. 

Suggested in: https://github.com/thiagoa/rbtagger/issues/46